### PR TITLE
Refactor/schema

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,6 @@ POSTGRES_PASSWORD=postgres
 # These must be loaded with python-dotenv.
 FLASK_ENV=development
 
-DB_CONN_STRING="host=localhost dbname=postgres user=postgres password=postgres"
+DB_CONN_STRING="host=localhost dbname=postgres user=postgres password=postgres port=5432"
 TEST_DB_CONN_STRING="host=localhost dbname=postgres user=postgres password=postgres port=5433"
 

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,11 @@
 fmt:
 	python -m black api
 	python -m isort api --profile=black
+
+POSTGRES_URL:='postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable'
+up:
+	export POSTGRES_URL=$(POSTGRES_URL)
+	migrate -database ${POSTGRES_URL} -path migrations up
+down:
+	export POSTGRES_URL=$(POSTGRES_URL)
+	migrate -database ${POSTGRES_URL} -path migrations down

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,5 @@ up:
 down:
 	export POSTGRES_URL=$(POSTGRES_URL)
 	migrate -database ${POSTGRES_URL} -path migrations down
+seed:
+	docker exec -it i2eye-back-2021-db-1 psql -U postgres -f /sql/seed.sql

--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ pip install -r requirements.txt -r requirements-dev.txt
 
 2. Copy the contents of `.env.example` into a new file named `.env`. This file is used to provision environment variables and other secrets.
 3. From the root directory, run `docker-compose up -d`. This spins up a postgres container, bound to port 5432 on the host, and applies all migrations.
-4. To start the Flask application, use `flask run`.
+4. Then use `make seed` to seed some initial values.
+5. To start the Flask application, use `flask run`.

--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ pip install -r requirements.txt -r requirements-dev.txt
 ```
 
 2. Copy the contents of `.env.example` into a new file named `.env`. This file is used to provision environment variables and other secrets.
-3. From the root directory, run `docker-compose up -d`. This will spin up two Postgres containers, one for developing, and one for testing. The dev database is bound to port 5432, and the test database is bound to port 5433.
+3. From the root directory, run `docker-compose up -d`. This spins up a postgres container, bound to port 5432 on the host, and applies all migrations.
 4. To start the Flask application, use `flask run`.

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -7,10 +7,6 @@ def create_app(config: str = "config.DevConfig"):
     app.config.from_object(config)
 
     with app.app_context():
-        from api.psql.utils import db_setup
-
         from . import routes  # noqa: F401
-
-        db_setup()
 
         return app

--- a/api/psql/__init__.py
+++ b/api/psql/__init__.py
@@ -1,5 +1,9 @@
-from flask import current_app as app
+from os import environ
+
+from dotenv import load_dotenv
 from psycopg2.pool import ThreadedConnectionPool
 
+load_dotenv()
+
 # Create a connection pool.
-db = ThreadedConnectionPool(5, 20, app.config["DB_CONN_STRING"])
+db = ThreadedConnectionPool(5, 20, environ.get("DB_CONN_STRING"))

--- a/api/psql/utils.py
+++ b/api/psql/utils.py
@@ -1,3 +1,4 @@
+from openpyxl import Workbook
 from psycopg2.extensions import connection
 
 from . import db
@@ -157,3 +158,53 @@ def copy_query_to_file(query: str, file, conn: connection) -> None:
     q = f"COPY {query} TO STDOUT WITH CSV HEADER"
     cursor = conn.cursor()
     cursor.copy_expert(q, file)
+
+
+def to_xlsx(conn: connection):
+    """to_xlsx returns a openpyxl Workbook object.
+
+    Each station is its own sheet. The first column of each
+    sheet contains the questions at that station. Each subsequent
+    column represents a single patient's responses to the
+    questions. The patient's column is given by patient_id+1, and
+    this is shared across worksheets.
+    """
+    wb = Workbook()
+    cursor = conn.cursor()
+
+    # take all station names first to create the worksheets
+    cursor.execute("select distinct station_id, station_name from station;")
+    res = cursor.fetchall()
+    station_ids = [x[0] for x in res]
+    station_names = [x[1] for x in res]
+    for sname in station_names:
+        wb.create_sheet(sname)
+
+    # now grab the remaining data for each station
+    for (sid, sname) in zip(station_ids, station_names):
+        cursor.execute(
+            f"""
+        select q.question_id, q.question, a.answer, a.patient_id
+        from question q inner join answer a
+        on q.question_id=a.question_id
+        where q.station_id={sid}
+        order by q.question_id;
+        """
+        )
+        res = cursor.fetchall()
+        ws = wb.get_sheet_by_name(sname)
+
+        # create a map from qid to the row num, so that rows
+        # are flushed to the top
+        qmap = {}
+        for (i, qid) in enumerate({x[0] for x in res}):
+            qmap[qid] = i + 1
+
+        for (qid, q) in {(x[0], x[1]) for x in res}:
+            ws.cell(row=qmap[qid], column=1, value=q)
+
+        for x in res:
+            qid, ans, pid = x[0], x[2], x[3]
+            ws.cell(row=qmap[qid], column=pid + 1, value=ans)
+
+    return wb

--- a/api/psql/utils.py
+++ b/api/psql/utils.py
@@ -150,3 +150,10 @@ def insert_answer(patient_id, answer, question_id, station_id, conn: connection)
     conn.commit()
     count = cursor.rowcount
     print(count, "Record inserted successfully into answer table")
+
+
+def copy_query_to_file(query: str, file, conn: connection) -> None:
+    """Copies results from a query into a file-like object, in csv format."""
+    q = f"COPY {query} TO STDOUT WITH CSV HEADER"
+    cursor = conn.cursor()
+    cursor.copy_expert(q, file)

--- a/api/routes/__init__.py
+++ b/api/routes/__init__.py
@@ -1,2 +1,2 @@
 # flake8: noqa
-from . import patient, question, registration, station
+from . import patient, question, registration, station, files

--- a/api/routes/files.py
+++ b/api/routes/files.py
@@ -1,0 +1,17 @@
+from io import StringIO
+
+from api.psql import db
+from api.psql.utils import copy_query_to_file
+from flask import Response
+from flask import current_app as app
+
+
+@app.route("/patients.csv", methods=["GET"])
+def serve_patients_csv():
+    buf = StringIO()
+    with db.getconn() as conn:
+        copy_query_to_file("patient", buf, conn)
+        buf.flush()  # Do we need this?
+    res = Response(buf.getvalue(), status=200, mimetype="text/csv")
+    res.headers.set("Content-Disposition", "attachment", filename="patients.csv")
+    return res

--- a/api/routes/files.py
+++ b/api/routes/files.py
@@ -15,3 +15,13 @@ def serve_patients_csv():
     res = Response(buf.getvalue(), status=200, mimetype="text/csv")
     res.headers.set("Content-Disposition", "attachment", filename="patients.csv")
     return res
+
+@app.route("/questions.csv", methods=["GET"])
+def get_questions_csv():
+    buf = StringIO()
+    with db.getconn() as conn:
+        copy_query_to_file("question", buf, conn)
+        buf.flush() 
+    res = Response(buf.getvalue(), status=200, mimetype="text/csv")
+    res.headers.set("Content-Disposition", "attachment", filename="questions.csv")
+    return res

--- a/api/routes/files.py
+++ b/api/routes/files.py
@@ -25,3 +25,25 @@ def get_questions_csv():
     res = Response(buf.getvalue(), status=200, mimetype="text/csv")
     res.headers.set("Content-Disposition", "attachment", filename="questions.csv")
     return res
+
+
+@app.route("/registration.csv", methods=["GET"])
+def get_registration_csv():
+    buf = StringIO()
+    with db.getconn() as conn:
+        copy_query_to_file("registration", buf, conn)
+        buf.flush() 
+    res = Response(buf.getvalue(), status=200, mimetype="text/csv")
+    res.headers.set("Content-Disposition", "attachment", filename="registration.csv")
+    return res
+
+
+@app.route("/stations.csv", methods=["GET"])
+def get_stations_csv():
+    buf = StringIO()
+    with db.getconn() as conn:
+        copy_query_to_file("station", buf, conn)
+        buf.flush() 
+    res = Response(buf.getvalue(), status=200, mimetype="text/csv")
+    res.headers.set("Content-Disposition", "attachment", filename="stations.csv")
+    return res

--- a/api/routes/files.py
+++ b/api/routes/files.py
@@ -27,16 +27,6 @@ def get_questions_csv():
     return res
 
 
-@app.route("/registration.csv", methods=["GET"])
-def get_registration_csv():
-    buf = StringIO()
-    with db.getconn() as conn:
-        copy_query_to_file("registration", buf, conn)
-        buf.flush() 
-    res = Response(buf.getvalue(), status=200, mimetype="text/csv")
-    res.headers.set("Content-Disposition", "attachment", filename="registration.csv")
-    return res
-
 
 @app.route("/stations.csv", methods=["GET"])
 def get_stations_csv():
@@ -46,4 +36,25 @@ def get_stations_csv():
         buf.flush() 
     res = Response(buf.getvalue(), status=200, mimetype="text/csv")
     res.headers.set("Content-Disposition", "attachment", filename="stations.csv")
+    return res
+
+
+@app.route("/answers.csv", methods=["GET"])
+def get_answers_csv():
+    buf = StringIO()
+    with db.getconn() as conn:
+        copy_query_to_file("answer", buf, conn)
+        buf.flush() 
+    res = Response(buf.getvalue(), status=200, mimetype="text/csv")
+    res.headers.set("Content-Disposition", "attachment", filename="answers.csv")
+    return res
+
+@app.route("/types.csv", methods=["GET"])
+def get_types_csv():
+    buf = StringIO()
+    with db.getconn() as conn:
+        copy_query_to_file("type", buf, conn)
+        buf.flush() 
+    res = Response(buf.getvalue(), status=200, mimetype="text/csv")
+    res.headers.set("Content-Disposition", "attachment", filename="types.csv")
     return res

--- a/api/routes/files.py
+++ b/api/routes/files.py
@@ -1,9 +1,11 @@
 from io import StringIO
+from tempfile import NamedTemporaryFile
 
 from api.psql import db
-from api.psql.utils import copy_query_to_file
+from api.psql.utils import copy_query_to_file, to_xlsx
 from flask import Response
 from flask import current_app as app
+from flask import send_file
 
 
 @app.route("/patients.csv", methods=["GET"])
@@ -16,16 +18,16 @@ def serve_patients_csv():
     res.headers.set("Content-Disposition", "attachment", filename="patients.csv")
     return res
 
+
 @app.route("/questions.csv", methods=["GET"])
 def get_questions_csv():
     buf = StringIO()
     with db.getconn() as conn:
         copy_query_to_file("question", buf, conn)
-        buf.flush() 
+        buf.flush()
     res = Response(buf.getvalue(), status=200, mimetype="text/csv")
     res.headers.set("Content-Disposition", "attachment", filename="questions.csv")
     return res
-
 
 
 @app.route("/stations.csv", methods=["GET"])
@@ -33,7 +35,7 @@ def get_stations_csv():
     buf = StringIO()
     with db.getconn() as conn:
         copy_query_to_file("station", buf, conn)
-        buf.flush() 
+        buf.flush()
     res = Response(buf.getvalue(), status=200, mimetype="text/csv")
     res.headers.set("Content-Disposition", "attachment", filename="stations.csv")
     return res
@@ -44,17 +46,27 @@ def get_answers_csv():
     buf = StringIO()
     with db.getconn() as conn:
         copy_query_to_file("answer", buf, conn)
-        buf.flush() 
+        buf.flush()
     res = Response(buf.getvalue(), status=200, mimetype="text/csv")
     res.headers.set("Content-Disposition", "attachment", filename="answers.csv")
     return res
+
 
 @app.route("/types.csv", methods=["GET"])
 def get_types_csv():
     buf = StringIO()
     with db.getconn() as conn:
         copy_query_to_file("type", buf, conn)
-        buf.flush() 
+        buf.flush()
     res = Response(buf.getvalue(), status=200, mimetype="text/csv")
     res.headers.set("Content-Disposition", "attachment", filename="types.csv")
     return res
+
+
+@app.route("/summary.xlsx", methods=["GET"])
+def get_summary():
+    with db.getconn() as conn:
+        wb = to_xlsx(conn)
+        with NamedTemporaryFile(suffix=".xlsx") as fp:
+            wb.save(fp.name)
+            return send_file(fp.name, mimetype="xlsx", as_attachment=True)

--- a/api/routes/patient.py
+++ b/api/routes/patient.py
@@ -1,10 +1,9 @@
 import json
 
 import psycopg2
+from api.psql import db
 from flask import current_app as app
 from flask import request
-
-from api.psql import db
 
 
 @app.route("/get_all_patients", methods=["GET"])
@@ -90,7 +89,7 @@ def get_all_patients():
                 this_patient_data.update({station_name: outcome})
 
             availability_query = (
-                """SELECT status from patient WHERE patient_id = {0}""".format(id)
+                """SELECT available from patient WHERE patient_id = {0}""".format(id)
             )
             cursor.execute(availability_query)
             connection.commit()
@@ -231,8 +230,8 @@ def delete_patient(patient_id):
         return "patient successfully deleted"
 
 
-@app.route("/update_patient_status", methods=["POST"])
-def update_patient_status():
+@app.route("/set_patient_availability", methods=["POST"])
+def set_patient_availability():
     with db.getconn() as connection:
         cursor = connection.cursor()
 
@@ -245,16 +244,16 @@ def update_patient_status():
                 patient_id = value
 
             if key == "boolean":
-                patient_status = value
+                available = value
 
             # print(key)
             # print(value)
 
         postgres_update_query = (
-            """ UPDATE patient SET status = %s WHERE patient_id = %s"""
+            """ UPDATE patient SET available = %s WHERE patient_id = %s"""
         )
         record_to_update = (
-            patient_status,
+            available,
             patient_id,
         )
         cursor.execute(postgres_update_query, record_to_update)

--- a/api/routes/station.py
+++ b/api/routes/station.py
@@ -1,7 +1,6 @@
+from api.psql import db
 from flask import current_app as app
 from flask import request
-
-from api.psql import db
 
 
 @app.route("/get_availability", methods=["GET"])
@@ -9,7 +8,7 @@ def get_station_availability():
     with db.getconn() as connection:
         cursor = connection.cursor()
 
-        postgres_select_query = """SELECT station_name, availability FROM station"""
+        postgres_select_query = """SELECT station_name, available FROM station"""
         cursor.execute(postgres_select_query)
         connection.commit()
 
@@ -38,7 +37,7 @@ def set_availability():
         print(data)
         for key, value in data.items():
             postgres_select_query = (
-                """ UPDATE station SET availability = %s WHERE station_name = %s"""
+                """UPDATE station SET available = %s WHERE station_name = %s"""
             )
             record_to_select = (
                 value,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: "3"
 services:
   db:
     image: postgres:latest
+    networks:
+      - eye
     ports:
       - 5432:5432
     environment:
@@ -9,13 +11,22 @@ services:
       POSTGRES_USER: $POSTGRES_USER
       POSTGRES_PASSWORD: $POSTGRES_PASSWORD
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 10s
+      retries: 5
 
-  test_db:
-    image: postgres:latest
-    ports:
-      - 5433:5432
-    environment:
-      POSTGRES_DB: $POSTGRES_DB
-      POSTGRES_USER: $POSTGRES_USER
-      POSTGRES_PASSWORD: $POSTGRES_PASSWORD
-    restart: unless-stopped
+  migrate:
+    image: migrate/migrate
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - eye
+    volumes:
+      - ./migrations/:/migrations/
+    command: ["-database", $POSTGRES_URL, "-path", "migrations", "up"]
+
+networks:
+  eye:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       interval: 2s
       timeout: 10s
       retries: 5
+    volumes:
+      - ./seed.sql:/sql/seed.sql
 
   migrate:
     image: migrate/migrate

--- a/migrations/000001_create_station_table.down.sql
+++ b/migrations/000001_create_station_table.down.sql
@@ -1,0 +1,1 @@
+drop table if exists station;

--- a/migrations/000001_create_station_table.up.sql
+++ b/migrations/000001_create_station_table.up.sql
@@ -1,5 +1,5 @@
 create table if not exists station (
 	station_id serial primary key,
 	station_name text unique not null,
-	available boolean not null
+	available boolean not null default true
 );

--- a/migrations/000001_create_station_table.up.sql
+++ b/migrations/000001_create_station_table.up.sql
@@ -1,0 +1,5 @@
+create table if not exists station (
+	station_id serial primary key,
+	station_name text unique not null,
+	available boolean not null
+);

--- a/migrations/000002_create_patient_table.down.sql
+++ b/migrations/000002_create_patient_table.down.sql
@@ -1,6 +1,1 @@
-begin;
-
 drop table if exists patient;
-drop type patient_status;
-
-commit;

--- a/migrations/000002_create_patient_table.down.sql
+++ b/migrations/000002_create_patient_table.down.sql
@@ -1,0 +1,6 @@
+begin;
+
+drop table if exists patient;
+drop type patient_status;
+
+commit;

--- a/migrations/000002_create_patient_table.up.sql
+++ b/migrations/000002_create_patient_table.up.sql
@@ -1,5 +1,6 @@
 create table if not exists patient (
 	patient_id serial primary key,
+	name text,
 	available boolean not null default true,
 	current_station int references station(station_id) on update cascade on delete set null
 );

--- a/migrations/000002_create_patient_table.up.sql
+++ b/migrations/000002_create_patient_table.up.sql
@@ -1,13 +1,5 @@
-begin;
-
-create type patient_status as enum (
-	'occupied',
-	'free'
-);
-
 create table if not exists patient (
 	patient_id serial primary key,
-	status patient_status not null default 'free'
+	available boolean not null default true,
+	current_station int references station(station_id) on update cascade on delete set null
 );
-
-commit;

--- a/migrations/000002_create_patient_table.up.sql
+++ b/migrations/000002_create_patient_table.up.sql
@@ -1,0 +1,13 @@
+begin;
+
+create type patient_status as enum (
+	'occupied',
+	'free'
+);
+
+create table if not exists patient (
+	patient_id serial primary key,
+	status patient_status not null default 'free'
+);
+
+commit;

--- a/migrations/000003_create_patient_station_completed_table.down.sql
+++ b/migrations/000003_create_patient_station_completed_table.down.sql
@@ -1,0 +1,1 @@
+drop table if exists patient_station_completed;

--- a/migrations/000003_create_patient_station_completed_table.up.sql
+++ b/migrations/000003_create_patient_station_completed_table.up.sql
@@ -1,0 +1,5 @@
+create table patient_station_completed (
+	patient_id int references patient(patient_id) on update cascade on delete cascade,
+	station_id int references station(station_id) on update cascade on delete cascade,
+	constraint patient_station_pk primary key (patient_id, station_id)
+);

--- a/migrations/000004_create_question_table.down.sql
+++ b/migrations/000004_create_question_table.down.sql
@@ -1,0 +1,6 @@
+begin;
+
+drop table if exists question;
+drop type question_type;
+
+commit;

--- a/migrations/000004_create_question_table.up.sql
+++ b/migrations/000004_create_question_table.up.sql
@@ -1,0 +1,16 @@
+begin;
+
+create type question_type as enum (
+	'text',
+	'radio',
+	'checkbox'
+);
+
+create table if not exists question (
+	question_id serial primary key,
+	question text not null,
+	station_id int references station(station_id) on update cascade,
+	type question_type not null default 'text'
+);
+
+commit;

--- a/migrations/000005_create_answer_table.down.sql
+++ b/migrations/000005_create_answer_table.down.sql
@@ -1,0 +1,1 @@
+drop table if exists answer;

--- a/migrations/000005_create_answer_table.up.sql
+++ b/migrations/000005_create_answer_table.up.sql
@@ -1,0 +1,7 @@
+create table if not exists answer (
+	answer_id serial primary key,
+	answer text not null,
+	patient_id int references patient(patient_id) on update cascade,
+	question_id int references question(question_id) on update cascade,
+	station_id int references station(station_id) on update cascade
+);

--- a/migrations/000005_create_answer_table.up.sql
+++ b/migrations/000005_create_answer_table.up.sql
@@ -2,6 +2,5 @@ create table if not exists answer (
 	answer_id serial primary key,
 	answer text not null,
 	patient_id int references patient(patient_id) on update cascade,
-	question_id int references question(question_id) on update cascade,
-	station_id int references station(station_id) on update cascade
+	question_id int references question(question_id) on update cascade
 );

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 black==21.11b1
 flake8==4.0.1
 isort==5.10.1
+pytest==6.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 psycopg2==2.9.2
 Flask==2.0.2
 python-dotenv==0.19.2
+openpyxl==3.0.9

--- a/seed.sql
+++ b/seed.sql
@@ -1,0 +1,71 @@
+begin;
+
+-- create a bunch of stations
+insert into station(station_name) values
+	('Oral Health'),
+	('Phlebotomy Test');
+
+-- and a bunch of questions
+with q (question, type, station_name) as
+(values
+	('Have you ever consumed in the past/present any form of intoxications e.g. tobacco, beedi, cigarettes (include chewing/smoking)', 'radio', 'Oral Health'),
+	('If Y to having consumed, what do you consume', 'text', 'Oral Health'),
+	('Are you 40 years old or above', 'radio', 'Phlebotomy Test'),
+	('Are you suffering from any of the following conditions', 'checkbox', 'Phlebotomy Test')
+)
+insert into question (question, type, station_id)
+select q.question, q.type::question_type, s.station_id from
+q join station s on q.station_name=s.station_name;
+
+-- add some patients
+insert into patient(name) values
+	('Moja'),
+	('Newkii'),
+	('Kaiju');
+
+-- add some answers
+with a (answer, patient) as
+(values
+	('Y', 'Moja'),
+	('Y', 'Newkii'),
+	('Y', 'Kaiju')
+)
+insert into answer(answer, patient_id, question_id)
+select a.answer, p.patient_id, q.question_id from a
+join question q on q.question='Have you ever consumed in the past/present any form of intoxications e.g. tobacco, beedi, cigarettes (include chewing/smoking)'
+join patient p on a.patient=p.name;
+
+with a (answer, patient) as
+(values
+	('Canadian Geese', 'Moja'),
+	('Dog food', 'Newkii'),
+	('My enemies', 'Kaiju')
+)
+insert into answer(answer, patient_id, question_id)
+select a.answer, p.patient_id, q.question_id from a
+join question q on q.question='If Y to having consumed, what do you consume'
+join patient p on a.patient=p.name;
+
+with a (answer, patient) as
+(values
+	('Y', 'Moja'),
+	('N', 'Newkii'),
+	('Y', 'Kaiju')
+)
+insert into answer(answer, patient_id, question_id)
+select a.answer, p.patient_id, q.question_id from a
+join question q on q.question='Are you 40 years old or above'
+join patient p on a.patient=p.name;
+
+with a (answer, patient) as
+(values
+	('Depression', 'Moja'),
+	('Addicted to TikTok', 'Newkii'),
+	('Healthy boi', 'Kaiju')
+)
+insert into answer(answer, patient_id, question_id)
+select a.answer, p.patient_id, q.question_id from a
+join question q on q.question='Are you suffering from any of the following conditions'
+join patient p on a.patient=p.name;
+
+commit;


### PR DESCRIPTION
### Migrations

This adds a `migrations/` folder, and starts managing migrations with [golang-migrate](https://github.com/golang-migrate/migrate). From here, any changes to the database schema should be made by adding a file to the `migrations/` folder. See the golang-migrate [docs](https://github.com/golang-migrate/migrate/blob/master/database/postgres/TUTORIAL.md) for how to do this.

### Other changes
- Adds a bunch of endpoints to download tables as csv files
- One endpoint to download summary info as xlsx
- `patient.patient_status` renamed to `patient.available`
- The `type` table is now just an enum, `question_type`
```sql
create type question_type as enum (
	'text',
	'radio',
	'checkbox'
);
```

- Every relationship is now properly modeled with foreign keys. **Some old code will not work.** We have:
  - m2m between patients and stations for completed stations
  - o2o question and station (o2m station and question)
  - o2o answer and patient (o2m patient and answer)
  - o2o answer and question (o2m question and answer)
  - o2o answer and station (o2m station and answer)